### PR TITLE
update to the latest version of org.apache.cordova.geolocation 0.3.10

### DIFF
--- a/packages/mdg:geolocation/package.js
+++ b/packages/mdg:geolocation/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  "org.apache.cordova.geolocation": "0.3.9"
+  "org.apache.cordova.geolocation": "0.3.10"
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
Fixes issues with geolocation on iOS 8. As specified in release notes [here](https://git-wip-us.apache.org/repos/asf?p=cordova-plugin-geolocation.git;a=blob;f=RELEASENOTES.md;h=8a5e19831a78124b010b9b5fbbf19b6a0978cb45;hb=543afdf88a201131eb8f3109f4c135d6a671f513#l80)
