### PR TITLE
Enable passing custom options to camera.getPicture

### DIFF
--- a/packages/mdg:camera/package.js
+++ b/packages/mdg:camera/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mdg:camera",
   summary: "Photos with one function call on desktop and mobile.",
-  version: "1.0.2",
+  version: "1.0.3",
   git: "https://github.com/meteor/mobile-packages"
 });
 

--- a/packages/mdg:camera/photo-cordova.js
+++ b/packages/mdg:camera/photo-cordova.js
@@ -13,10 +13,12 @@ MeteorCamera.getPicture = function (options, callback) {
     callback(new Meteor.Error("cordovaError", error));
   };
 
-  navigator.camera.getPicture(success, failure, {
-    quality: options.quality || 49,
-    targetWidth: options.width || 640,
-    targetHeight: options.width || 480,
-    destinationType: Camera.DestinationType.DATA_URL
-  });
+  navigator.camera.getPicture(success, failure, 
+    _.extend(options, {
+      quality: options.quality || 49,
+      targetWidth: options.width || 640,
+      targetHeight: options.width || 480,
+      destinationType: Camera.DestinationType.DATA_URL
+    })
+  );
 };


### PR DESCRIPTION
Right now there is no way to provide other options to getPicture than the ones explicitly defined. For example you can not give { correctOrientation: true }

This patch allows you to provide such options via options argument of the getPicture function.
