### PR TITLE
Fix setting targetHeight option for getPicture.

### DIFF
--- a/packages/mdg:camera/photo-cordova.js
+++ b/packages/mdg:camera/photo-cordova.js
@@ -17,7 +17,7 @@ MeteorCamera.getPicture = function (options, callback) {
     _.extend(options, {
       quality: options.quality || 49,
       targetWidth: options.width || 640,
-      targetHeight: options.width || 480,
+      targetHeight: options.height || 480,
       destinationType: Camera.DestinationType.DATA_URL
     })
   );


### PR DESCRIPTION
There is a typo that sets tartgetHeight to options.width instead of options.height.
