### PR TITLE
Update camera.less

### DIFF
--- a/packages/mdg:camera/camera.less
+++ b/packages/mdg:camera/camera.less
@@ -7,7 +7,7 @@
   position: fixed;
   z-index: 1000;
   top: 20%;
-  width: 320px;
+  width: 360px;
   left: 50%;
   margin-left: -150px;
   font-family: sans-serif;


### PR DESCRIPTION
Stops the camera screen from overflowing from the modal. View finder has a width of 320px, plus the 40px border makes it 360px.
