### PR TITLE
Improve Geolocation package.

### DIFF
--- a/examples/simple-map/.meteor/versions
+++ b/examples/simple-map/.meteor/versions
@@ -25,7 +25,7 @@ jquery@1.0.1
 json@1.0.1
 livedata@1.0.11
 logging@1.0.4
-mdg:geolocation@1.0.2
+mdg:geolocation@1.0.3
 meteor-platform@1.1.2
 meteor@1.1.2
 minifiers@1.1.1

--- a/examples/simple-map/map.html
+++ b/examples/simple-map/map.html
@@ -7,6 +7,11 @@
 
   <img src="http://maps.googleapis.com/maps/api/staticmap?center={{loc.lat}},{{loc.lng}}&zoom=15&size=600x300&maptype=roadmap&markers=color:blue%7C{{loc.lat}},{{loc.lng}}" />
 
+  <label class="high-accuracy">
+    <input type="checkbox" checked="{{highAccuracy}}" />
+    High accuracy position
+  </label>
+
   {{#if error}}
     <p>Error: {{error.message}}</p>
   {{/if}}

--- a/examples/simple-map/map.js
+++ b/examples/simple-map/map.js
@@ -1,9 +1,22 @@
 if (Meteor.isClient) {
+  Template.body.events({
+    "change .high-accuracy input": function (event) {
+      Session.set("highAccuracy", event.target.checked);
+    }
+  });
   Template.body.helpers({
     loc: function () {
+      // options is *optional*.  We're including it in this demo
+      // to show how it is reactive.
+      var options = {
+        enableHighAccuracy: !!Session.get("highAccuracy")
+      };
       // return 0, 0 if the location isn't ready
-      return Geolocation.latLng() || { lat: 0, lng: 0 };
+      return Geolocation.latLng(options) || { lat: 0, lng: 0 };
     },
-    error: Geolocation.error
+    error: Geolocation.error,
+    highAccuracy: function() {
+      return Session.get("highAccuracy");
+    }
   });
 }

--- a/packages/mdg:geolocation/README.md
+++ b/packages/mdg:geolocation/README.md
@@ -10,10 +10,22 @@ There are currently no options to set. Every method is reactive using [Tracker](
 
 Returns the [position error](https://developer.mozilla.org/en-US/docs/Web/API/PositionError) that is currently preventing position updates.
 
-### Geolocation.currentLocation()
+### Geolocation.currentLocation(options)
 
 Returns the [position](https://developer.mozilla.org/en-US/docs/Web/API/Position) that is reported by the device, or null if no position is available.
 
-### Geolocation.latLng()
+The `options` parameter is optional; if provided it as if `Geolocation.setOptions` was called before returning the position.
+
+### Geolocation.latLng(options)
 
 A simple shorthand for currentLocation() when all you need is the latitude and longitude. Returns an object that has `lat` and `lng` keys.
+
+The `options` parameter is optional; if provided it as if `Geolocation.setOptions` was called before returning the position.
+
+### Geolocation.setOptions(options)
+
+Provide [PositionOptions](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) to manage power consumption on mobile devices.  The options can be reactive.
+
+### Geolocation.setPaused(boolean)
+
+If the parameter is `true`, temporarily halts reactive position updates to reduce power consumption.

--- a/packages/mdg:geolocation/package.js
+++ b/packages/mdg:geolocation/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mdg:geolocation",
   summary: "Provides reactive geolocation on desktop and mobile.",
-  version: "1.0.2",
+  version: "1.0.3",
   git: "https://github.com/meteor/mobile-packages"
 });
 


### PR DESCRIPTION
Add the ability to tweak the PositionOptions used for Geolocation, for
instance to use low-accuracy position to save battery on mobile devices.
The options parameter is reactive.

Add a `pause` feature to temporarily halt position updates, again to
allow better power management on mobile devices.  The paused status
is also reactive.

Stop position watcher when there are no dependencies of the location,
so that we automatically save power if (for example) a reactive map
view is not visible.
