### PR TITLE
Update camera.less

### DIFF
--- a/packages/mdg:camera/camera.less
+++ b/packages/mdg:camera/camera.less
@@ -14,6 +14,7 @@
   background: white;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   line-height: 1.3em;
+  pointer-events: auto;
 
   &.camera-popup-wide {
     width: 480px;


### PR DESCRIPTION
Ionic Modal specifies ``pointer-events:  none``, so when the camera modal appears on top the buttons are not clickable since it is not a descendent of the ``.modal-open``. To remedy this specific case and other possible cases the ``.camera-popup`` should specify ``pointer-events: auto``.