### PR TITLE
added timetout to force error when gps is disable

### DIFF
--- a/packages/mdg:geolocation/geolocation.js
+++ b/packages/mdg:geolocation/geolocation.js
@@ -10,7 +10,8 @@ var error = new ReactiveVar(null);
 // options for watchPosition
 var options = {
   enableHighAccuracy: true,
-  maximumAge: 0
+  maximumAge: 0,
+  timeout: 10000
 };
 
 var onError = function (newError) {


### PR DESCRIPTION
I added timetout of 10 seconds into option var, to force error when gps is disable.
Take a look: https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation#Fine_tuning_response