### PR TITLE
extending startWatchingPosition for custom options

### DIFF
--- a/packages/mdg:geolocation/geolocation.js
+++ b/packages/mdg:geolocation/geolocation.js
@@ -7,13 +7,6 @@ var location = new ReactiveVar(null);
 // error variable and dependency
 var error = new ReactiveVar(null);
 
-// options for watchPosition
-var options = {
-  enableHighAccuracy: true,
-  maximumAge: 0,
-  timeout: 10000
-};
-
 var onError = function (newError) {
   error.set(newError);
 };
@@ -23,9 +16,14 @@ var onPosition = function (newLocation) {
   error.set(null);
 };
 
-var startWatchingPosition = function () {
+var startWatchingPosition = function (options) {
+  var params = {
+    enableHighAccuracy: options.enableHighAccuracy || true,
+    maximumAge: options.maximumAge || 0,
+    timeout: options.timeout || 10000
+  };
   if (! watchingPosition && navigator.geolocation) {
-    navigator.geolocation.watchPosition(onPosition, onError, options);
+    navigator.geolocation.watchPosition(onPosition, onError, params);
     watchingPosition = true;
   }
 };
@@ -43,8 +41,8 @@ Geolocation = {
    * [position error](https://developer.mozilla.org/en-US/docs/Web/API/PositionError)
    * that is currently preventing position updates.
    */
-  error: function () {
-    startWatchingPosition();
+  error: function (options) {
+    startWatchingPosition(options);
     return error.get();
   },
 
@@ -54,8 +52,8 @@ Geolocation = {
    * [position](https://developer.mozilla.org/en-US/docs/Web/API/Position)
    * that is reported by the device, or null if no position is available.
    */
-  currentLocation: function () {
-    startWatchingPosition();
+  currentLocation: function (options) {
+    startWatchingPosition(options);
     return location.get();
   },
   // simple version of location; just lat and lng
@@ -65,8 +63,8 @@ Geolocation = {
    * @return {Object | null} An object with `lat` and `lng` properties,
    * or null if no position is available.
    */
-  latLng: function () {
-    var loc = Geolocation.currentLocation();
+  latLng: function (options) {
+    var loc = Geolocation.currentLocation(options);
 
     if (loc) {
       return {


### PR DESCRIPTION
I think this will be the best way to reuse geolocation options, because I'm needing to customize the options and this will make the package more flexible.
Please let me know when it will be available on atmosphere, thanks!
