### PR TITLE
Adjusting photo preview to fit into camera popup box

### DIFF
--- a/packages/mdg:camera/camera.less
+++ b/packages/mdg:camera/camera.less
@@ -39,7 +39,7 @@
   }
 
   .photo-preview {
-    width: 320px;
+    width: 280px;
   }
 
   padding: 20px;


### PR DESCRIPTION
After capturing a photo with the camera, the preview picture overflows the camera-popup div. The camera-popup div has

```
width: 320px;
padding: 20px;
```

which only leaves 280px for the content. The `preview-picture` class, however, configures a width of 320px. This adjust its width to 280px.

The css for `#video` does this correct already (280px).
