### PR TITLE
Fix #98

### DIFF
--- a/packages/mdg:camera/photo-browser.js
+++ b/packages/mdg:camera/photo-browser.js
@@ -114,7 +114,7 @@ Template.camera.events({
     }
     
     if (stream) {
-      stream.stop();
+      stream.getTracks().forEach(function (track) { track.stop(); });
     }
   }
 });


### PR DESCRIPTION
Issue #98 describes a console error occurring because of a recent change in the API. According to https://github.com/andyet/SimpleWebRTC/issues/363, this is the fix. @perak also appears to have applied this fix in https://github.com/perak/meteor-camera/.