### PR TITLE
provide a way to get access to photo content and to call closeAndCall…

### DIFF
--- a/packages/mdg:camera/photo-browser.js
+++ b/packages/mdg:camera/photo-browser.js
@@ -188,6 +188,8 @@ Template.camera.events({
       MeteorCamera.closeAndCallback(new Meteor.Error("cancel", "Photo taking was cancelled."));
     }
   },
+
+  // This part could be moved outside this package and each dev could add its own logic, because with MeteorCamera object he gets all he needs
   "change #videofallback": function(ev, tpl) {
     var files = ev.currentTarget.files; // FileList
     if(!files.length){
@@ -197,33 +199,12 @@ Template.camera.events({
 
     var reader  = new FileReader();
     reader.addEventListener("load", function () {
-      photo.set(reader.result);
+      MeteorCamera.getPhoto().set(reader.result);
     }, false);
 
     if (files[0]) {
       reader.readAsDataURL(files[0]);
     }
-/*
-    var vendorURL = window.URL || window.webkitURL;
-    var imageUrl = vendorURL.createObjectURL(files[0]);
-    var image = new Image();
-    image.src = imageUrl;
-
-    var canvas = tpl.find("canvas");
-
-    var fileCanvasWidth = canvas.width / image.width;
-    var fileCanvasHeight = canvas.height / image.height;
-    var ratio = Math.min(fileCanvasWidth, fileCanvasHeight);
-
-    canvas.width = canvasWidth;
-    canvas.height = canvasHeight;
-    canvas.getContext('2d').drawImage(image,
-      0, 0, image.width, image.height,
-      0, 0, image.width*ratio, image.height*ratio);
-    var data = canvas.toDataURL('image/jpeg', settings.quality);
-    photo.set(imageUrl /*data* /);
- */
-
   }
 });
 

--- a/packages/mdg:camera/photo.html
+++ b/packages/mdg:camera/photo.html
@@ -14,7 +14,7 @@
             {{> genericError message="There was an error accessing the camera."}}
           {{/if}}
         {{/if}}
-        <input type="file" accept="image/*" multiple="false" id="videofallback">
+        {{> cameraFallback}}
       {{/if}}
       {{#if photo}}
         <div class="center">
@@ -28,6 +28,15 @@
         {{> viewfinder}}
       {{/if}}
   </div>
+</template>
+
+<template name="cameraFallback">
+  <input type="file" accept="image/*" multiple="false" id="videofallback"/>
+  {{>cameraCanvas}}
+</template>
+
+<template name="cameraCanvas">
+  <canvas id="canvas" style="visibility: hidden;"></canvas>
 </template>
 
 <template name="viewfinder">
@@ -45,7 +54,7 @@
     </div>
   </div>
 
-  <canvas id="canvas" style="visibility: hidden"></canvas>
+  {{> cameraCanvas}}
 </template>
 
 <template name="genericError">

--- a/packages/mdg:camera/photo.html
+++ b/packages/mdg:camera/photo.html
@@ -10,11 +10,12 @@
       {{else}}
         {{#if browserNotSupportedError}}
           {{> genericError message="Sorry, this browser is currently not supported for camera functionality."}}
-        {{else}}
-          {{> genericError message="There was an error accessing the camera."}}
+          {{else}}
+            {{> genericError message="There was an error accessing the camera."}}
+          {{/if}}
         {{/if}}
+        <input type="file" accept="image/*" multiple="false" id="videofallback">
       {{/if}}
-    {{else}}
       {{#if photo}}
         <div class="center">
           <img src="{{photo}}" class="photo-preview" />
@@ -26,7 +27,6 @@
       {{else}}
         {{> viewfinder}}
       {{/if}}
-    {{/if}}
   </div>
 </template>
 
@@ -61,7 +61,7 @@
 
     <p>
       You have denied this app permission to use your camera.
-      If you would like to allow permissions, follow the directions for your
+      If you would like to allow permissions, follow the directions for your 
       browser below.
     </p>
 

--- a/packages/mdg:camera/photo.js
+++ b/packages/mdg:camera/photo.js
@@ -1,1 +1,66 @@
-MeteorCamera = {};
+MeteorCamera = (function() {
+  if (!UI) throw new Meteor.Error('Missing UI package');
+
+  var myStream,
+    myView,
+    myPhoto,
+    myCallback;
+
+  return {
+    closeAndCallback: function () {
+      var originalArgs = arguments;
+      if (myView) UI.remove(myView);
+      if (myPhoto) myPhoto.set(null);
+      if (myCallback) myCallback.apply(null, originalArgs);
+
+      this.stopStream();
+    },
+
+    setView: function (view) {
+      myView = view;
+      return this;
+    },
+
+    setPhoto: function (photo) {
+      myPhoto = photo;
+      return this;
+    },
+
+    getPhoto: function () {
+      return myPhoto;
+    },
+
+    setCallback: function (cb) {
+      myCallback = cb;
+      return this;
+    },
+
+    setStream: function (stream) {
+      myStream = stream;
+      return this;
+    },
+
+    getStream: function () {
+      return myStream;
+    },
+
+    stopStream: function() {
+      if (!myStream) return;
+
+      if(myStream.stop) {
+        myStream.stop();
+        return;
+      }
+
+      if(!myStream.getTracks) return;
+
+      var tracks = myStream.getTracks();
+      for(var i = 0; i < tracks.length; i++) {
+        var track = tracks[i];
+        if(track && track.stop) {
+          track.stop();
+        }
+      }
+    }
+  }
+})();


### PR DESCRIPTION
…back function to allow the template remove from DOM

It also add a way to specify options using Meteor.settings.public.Meteor.Camera :
{ camera: {type: "front"/"back", width: 640, height: 480, quality: 80, viewFinder: {width: 320, height: 240}}

fix #106
