### PR TITLE
Allow Cordova to be used in irregular Cordova Applications

### DIFF
--- a/packages/mdg:camera/package.js
+++ b/packages/mdg:camera/package.js
@@ -19,5 +19,5 @@ Package.onUse(function(api) {
   api.addFiles('photo.js');
   api.addFiles("camera.less", ["web.browser"]);
   api.addFiles('photo-browser.js', ['web.browser']);
-  api.addFiles('photo-cordova.js', ['web.cordova']);
+  api.addFiles('photo-cordova.js', ['web.cordova', "web.browser"]);
 });

--- a/packages/mdg:camera/photo-browser.js
+++ b/packages/mdg:camera/photo-browser.js
@@ -134,7 +134,7 @@ Template.camera.events({
     } else {
       closeAndCallback(new Meteor.Error("cancel", "Photo taking was cancelled."));
     }
-    
+
     if (stream) {
       stopStream(stream);
     }
@@ -173,7 +173,7 @@ Template.viewfinder.helpers({
  * 2. data, a Data URI string with the image encoded in JPEG format, ready to
  * use as the `src` attribute on an `<img />` tag.
  */
-MeteorCamera.getPicture = function (options, callback) {
+MeteorCamera.getPictureBrowser = function (options, callback) {
   // if options are not passed
   if (! callback) {
     callback = options;
@@ -198,14 +198,14 @@ MeteorCamera.getPicture = function (options, callback) {
   canvasHeight = Math.round(canvasHeight);
 
   var view;
-  
+
   closeAndCallback = function () {
     var originalArgs = arguments;
     UI.remove(view);
     photo.set(null);
     callback.apply(null, originalArgs);
   };
-  
+
   view = UI.renderWithData(Template.camera);
   UI.insert(view, document.body);
 };

--- a/packages/mdg:camera/photo-cordova.js
+++ b/packages/mdg:camera/photo-cordova.js
@@ -1,4 +1,4 @@
-MeteorCamera.getPicture = function (options, callback) {
+MeteorCamera.getPictureCordova = function (options, callback) {
   // if options are not passed
   if (! callback) {
     callback = options;
@@ -13,7 +13,7 @@ MeteorCamera.getPicture = function (options, callback) {
     callback(new Meteor.Error("cordovaError", error));
   };
 
-  navigator.camera.getPicture(success, failure, 
+  navigator.camera.getPicture(success, failure,
     _.extend(options, {
       quality: options.quality || 49,
       targetWidth: options.width || 640,

--- a/packages/mdg:camera/photo.js
+++ b/packages/mdg:camera/photo.js
@@ -1,1 +1,9 @@
 MeteorCamera = {};
+
+MeteorCamera.getPicture = function (options, callback) {
+  if (Meteor.isCordova || options.forceCordova) {
+    MeteorCamera.getPictureCordova(options, callback);
+  } else {
+    MeteorCamera.getPictureBrowser(options, callback);
+  }
+}


### PR DESCRIPTION
I am running a Meteor app using Cordova but not using Meteor's Cordova build tools, since they do not give their users enough control, this PR adds the ability to use the Cordova camera plugin even when Meteor does not recognize the app as a Cordova app.
