### PR TITLE
Update cordova-plugin-geolocation version

### DIFF
--- a/packages/mdg:geolocation/package.js
+++ b/packages/mdg:geolocation/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  "cordova-plugin-geolocation": "2.1.0"
+  "cordova-plugin-geolocation": "2.4.3"
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
Fixes this Meteor 1.6 warning:

> WARNING: Attempting to install plugin cordova-plugin-geolocation@2.1.0, but it should have a minimum version of 2.4.3 to ensure compatibility with the current platform versions. Installing the minimum version for convenience,
         but you should adjust your dependencies.
