### PR TITLE
Update cordova-plugin-camera version

### DIFF
--- a/packages/mdg:camera/package.js
+++ b/packages/mdg:camera/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  "cordova-plugin-camera": "2.1.1"
+  "cordova-plugin-camera": "2.4.1"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Fixes this Meteor 1.6 error:

> WARNING: Attempting to install plugin cordova-plugin-camera@2.1.1, but it should have a minimum version of 2.4.1 to ensure compatibility with the current platform versions. Installing the minimum version for convenience, but
         you should adjust your dependencies.